### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
 name: Publish package to npm
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/BrewnodeDave/brewnode-server/security/code-scanning/10](https://github.com/BrewnodeDave/brewnode-server/security/code-scanning/10)

To fix this problem, add a `permissions` block either at the root of the workflow (to apply to all jobs) or within the `publish` job specifically. In this case, the safest and clearest solution is to add a root-level `permissions` block with the minimum required privileges. Since this workflow primarily checks out code and publishes to npm (using a secret), it typically needs only `contents: read` at minimum. If future jobs need extra permissions, these can be added on a per-job basis. Make the change to `.github/workflows/npm-publish.yml` by adding a section:
```yaml
permissions:
  contents: read
```
immediately after the `name` field (before `on:`), which will apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
