### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-on-release.yml
+++ b/.github/workflows/publish-on-release.yml
@@ -1,4 +1,6 @@
 name: Create Github release
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/BrewnodeDave/brewnode-server/security/code-scanning/11](https://github.com/BrewnodeDave/brewnode-server/security/code-scanning/11)

To fix this issue, you should add a `permissions` key to the workflow. This can be placed at the top (applies to all jobs), or inside the `jobs.release` block (applies only to that job). Both `actions/create-release` and `softprops/action-gh-release` require write access to `contents`, so these jobs need at minimum `contents: write`. 

The optimal solution is:  
- Add a `permissions` block at the **workflow root** with the value `contents: write` immediately after the `name:` (or after `on:`), to apply the minimum needed permissions globally for this workflow (since only one job is present).
- No other tokens seem to require additional write access (e.g., `issues` or `pull-requests`), so only `contents: write` is necessary.

**Required changes:**  
- In `.github/workflows/publish-on-release.yml`, insert a `permissions:` block with `contents: write` beneath the `name:` or `on:` block (conventional placement is directly after `name:` and before `on:`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
