### PR TITLE
feat: email alerts on brewlog errors and criticals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "ds18x20": "^0.2.0",
         "mysql": "^2.18.1",
         "nanotimer": "^0.3.15",
+        "nodemailer": "^8.0.3",
         "oas3-tools": "^2.2.3",
         "rollbar": "^2.26.4",
         "socket.io": "^4.8.0"
@@ -7678,6 +7679,15 @@
       "integrity": "sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.3.tgz",
+      "integrity": "sha512-JQNBqvK+bj3NMhUFR3wmCl3SYcOeMotDiwDBvIoCuQdF0PvlIY0BH+FJ2CG7u4cXKPChplE78oowlH/Otsc4ZQ==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-package-data": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "ds18x20": "^0.2.0",
     "mysql": "^2.18.1",
     "nanotimer": "^0.3.15",
+    "nodemailer": "^8.0.3",
     "oas3-tools": "^2.2.3",
     "rollbar": "^2.26.4",
     "socket.io": "^4.8.0"

--- a/src/brewstack/common/brewlog.js
+++ b/src/brewstack/common/brewlog.js
@@ -19,6 +19,7 @@ const brewdefs = require('./brewdefs.js');
 let rollbar;
 const Rollbar = require('rollbar');
 const mysqlService = require('../../services/mysql-service.js');
+const emailService = require('../../services/email-service.js');
 
 								
 let prevPower = null;
@@ -156,6 +157,7 @@ module.exports = {
 			} else {
 				gLogger.error(msg);
 			}
+			emailService.sendAlert(`Error: ${msg}`, data ? `${msg}\n\n${data}` : msg);
 		}	
 	},
 
@@ -169,6 +171,7 @@ module.exports = {
 			} else {
 				gLogger.error(msg);
 			}
+			emailService.sendAlert(`Critical: ${msg}`, data ? `${msg}\n\n${data}` : msg);
 		}
 	},
 

--- a/src/services/email-service.js
+++ b/src/services/email-service.js
@@ -1,0 +1,84 @@
+/*
+ * Beerware License
+ * ----------------
+ * As long as you retain this notice, you can do whatever you want with 
+ * this stuff. If we meet someday, and you think this stuff is worth it, 
+ * you can buy me a beer in return.
+ */
+
+/**
+ * Email Notification Service
+ * @module email-service
+ * @desc Sends email alerts on brewnode errors and critical events via nodemailer.
+ *       Configure via environment variables (see .env).
+ *
+ * Required env vars:
+ *   EMAIL_HOST      - SMTP host        (e.g. mail.example.com)
+ *   EMAIL_PORT      - SMTP port        (e.g. 465 for SSL, 587 for STARTTLS)
+ *   EMAIL_SECURE    - "true" for SSL   (omit or "false" for STARTTLS)
+ *   EMAIL_USER      - SMTP login
+ *   EMAIL_PASSWORD  - SMTP password
+ *   EMAIL_FROM      - From address     (e.g. brewnode@example.com)
+ *   EMAIL_TO        - Recipient(s)     (comma-separated)
+ */
+
+const nodemailer = require('nodemailer');
+
+const {
+    EMAIL_HOST,
+    EMAIL_PORT,
+    EMAIL_SECURE,
+    EMAIL_USER,
+    EMAIL_PASSWORD,
+    EMAIL_FROM,
+    EMAIL_TO,
+} = process.env;
+
+const configured = !!(EMAIL_HOST && EMAIL_USER && EMAIL_PASSWORD && EMAIL_TO);
+
+let transporter = null;
+
+if (configured) {
+    transporter = nodemailer.createTransport({
+        host: EMAIL_HOST,
+        port: parseInt(EMAIL_PORT || '587', 10),
+        secure: EMAIL_SECURE === 'true',
+        auth: {
+            user: EMAIL_USER,
+            pass: EMAIL_PASSWORD,
+        },
+    });
+}
+
+// Throttle: don't send more than one email per subject per THROTTLE_MS window.
+const THROTTLE_MS = 60 * 1000; // 1 minute
+const lastSent = new Map();
+
+/**
+ * Send an alert email. Silently no-ops if email is not configured.
+ * Throttled to one email per unique subject per minute.
+ * @param {string} subject
+ * @param {string} body
+ */
+async function sendAlert(subject, body) {
+    if (!configured || !transporter) return;
+
+    const now = Date.now();
+    const last = lastSent.get(subject) || 0;
+    if (now - last < THROTTLE_MS) return;
+    lastSent.set(subject, now);
+
+    try {
+        await transporter.sendMail({
+            from: EMAIL_FROM || EMAIL_USER,
+            to: EMAIL_TO,
+            subject: `[BrewNode] ${subject}`,
+            text: `${new Date().toISOString()}\n\n${body}`,
+        });
+    } catch (err) {
+        // Log to console only — avoid recursive brewlog call
+        console.error(`[email-service] Failed to send alert "${subject}":`, err.message);
+    }
+}
+
+module.exports = { sendAlert, configured };


### PR DESCRIPTION
## Summary

Sends an email alert whenever `brewlog.error()` or `brewlog.critical()` is called.

## Changes

### New file: `src/services/email-service.js`
- Nodemailer-based email service
- Throttled to one email per unique subject per minute (prevents spam during repeated errors)
- Silently no-ops if `EMAIL_*` env vars are not configured

### Modified: `src/brewstack/common/brewlog.js`
- Imports `email-service`
- `error()` and `critical()` now call `sendAlert()`

### Modified: `.env`
- Added `EMAIL_HOST`, `EMAIL_PORT`, `EMAIL_SECURE`, `EMAIL_USER`, `EMAIL_PASSWORD`, `EMAIL_FROM`, `EMAIL_TO`

## Configuration

Set the following in `.env` to enable:
```
EMAIL_HOST=mail.example.com
EMAIL_PORT=465
EMAIL_SECURE=true
EMAIL_USER=you@example.com
EMAIL_PASSWORD=yourpassword
EMAIL_FROM=you@example.com
EMAIL_TO=you@example.com
```

Leave any required field blank to disable email alerting entirely.

## Testing

- SMTP connection verified against `mail.brewnode.co.uk:465`
- End-to-end test via `brewlog.error()` confirmed email delivery
- All 245 existing tests pass